### PR TITLE
Turn off default features for sherpa-rs-sys dependency in sherpa-rs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ keywords = [
 [dependencies]
 eyre = "0.6.12"
 hound = { version = "3.5.1" }
-sherpa-rs-sys = { path = "sys", version = "0.5.1-beta.0" }
+sherpa-rs-sys = { path = "sys", version = "0.5.1-beta.0", default-features = false }
 tracing = "0.1.40"
 
 [dev-dependencies]


### PR DESCRIPTION
`sherpa-rs = { version = "...", default-features = false, ... }` won't work properly unless we disable default features for the `sherpa-rs-sys` dependency inside it. Since we pass all feature flags down to `sherpa-rs-sys` anyway (including the defaults) this fixes that issue.