### PR TITLE
fix: mobile linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vits-*
 sherpa-onnx-kws-*
 .tmp/
 jniLibs/
+build/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -192,7 +192,7 @@ New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
 
 ### Debug build
 
-For debug the build process of sherpa-onnx, please set `BUILD_DEBUG=1` environment variable before build.
+For debug the build process of sherpa-onnx, please set `SHERPA_BUILD_DEBUG=1` environment variable before build.
 
 ## Release new version
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -220,7 +220,7 @@ You must install NDK from Android Studio settings.
 rustup target add aarch64-linux-android
 cargo install cargo-ndk
 export NDK_HOME="$HOME/Library/Android/sdk/ndk/27.0.12077973"
-cargo ndk -t arm64-v8a -o ./jniLibs build --release
+cargo ndk -t arm64-v8a build --release
 ```
 
 ## Build for IOS

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -245,5 +245,6 @@ rustup target add aarch64-apple-ios-sim
 Build
 
 ```console
+export RUSTFLAGS="-C link-arg=-fapple-link-rtlib" # See https://github.com/bmrlab/gendam/issues/96
 cargo build --release --target aarch64-apple-ios
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Rust bindings to [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx)
 - Windows
 - Linux
 - macOS
+- Android
+- IOS
 
 ## Install
 

--- a/crates/sherpa-rs-sys/Cargo.toml
+++ b/crates/sherpa-rs-sys/Cargo.toml
@@ -37,6 +37,8 @@ include = [
 bindgen = "0.69.4"
 cmake = "0.1"
 glob = "0.3.1"
+lazy_static = { version = "1.5.0" }
+
 # Download binaries
 ureq = { version = "2.1", optional = true, default-features = false, features = [
     "tls",
@@ -49,7 +51,6 @@ sha2 = { version = "0.10", optional = true }
 dirs = { version = "5.0.1", optional = true }
 serde_json = { version = "1.0.134", optional = true }
 serde = { version = "1.0.216", features = ["derive"], optional = true }
-lazy_static = { version = "1.5.0", optional = true }
 
 
 [features]
@@ -63,7 +64,6 @@ download-binaries = [
     "dep:dirs",
     "dep:serde_json",
     "dep:serde",
-    "dep:lazy_static",
 ]
 static = []
 tts = []

--- a/crates/sherpa-rs-sys/build.rs
+++ b/crates/sherpa-rs-sys/build.rs
@@ -494,10 +494,6 @@ fn main() {
         link_lib("c++", true);
     }
 
-    if target_os == "ios" {
-        println!("cargo:rustc-link-arg=Metal");
-    }
-
     // Linux
     if target_os == "linux" || target == "android" {
         link_lib("stdc++", true);

--- a/crates/sherpa-rs-sys/build.rs
+++ b/crates/sherpa-rs-sys/build.rs
@@ -414,7 +414,7 @@ fn main() {
             if is_mobile {
                 env::set_var("SHERPA_LIB_PATH", &cache_dir);
             } else {
-                env::set_var("SHERPA_LIB_PATH", &cache_dir.join(&dist.name));
+                env::set_var("SHERPA_LIB_PATH", cache_dir.join(&dist.name));
             }
 
             debug_log!("dist libs: {:?}", dist.libs);

--- a/crates/sherpa-rs-sys/build.rs
+++ b/crates/sherpa-rs-sys/build.rs
@@ -519,6 +519,7 @@ fn main() {
             libs_assets.extend(extract_lib_assets(Path::new(&sherpa_lib_path), &target_os));
         }
 
+        #[cfg(feature = "download-binaries")]
         if let Some(dist) = optional_dist {
             if let Some(assets) = dist.libs {
                 if let Ok(sherpa_lib_path) = env::var("SHERPA_LIB_PATH") {

--- a/crates/sherpa-rs-sys/dist.json
+++ b/crates/sherpa-rs-sys/dist.json
@@ -20,6 +20,7 @@
         },
         "android": {
             "archive": "sherpa-onnx-{tag}-android.tar.bz2",
+            "is_dynamic": true,
             "arch": {
                 "aarch64-linux-android": "arm64-v8a",
                 "x86_64-linux-android": "x86_64",
@@ -32,6 +33,7 @@
         },
         "ios": {
             "archive": "sherpa-onnx-{tag}-ios.tar.bz2",
+            "is_dynamic": false,
             "arch": {
                 "aarch64-apple-ios": "ios-arm64",
                 "aarch64-apple-ios-sim": "ios-arm64-simulator"


### PR DESCRIPTION
TODO:

- IOS failed to link

```console
Undefined symbols for architecture arm64:
            "___isPlatformVersionAtLeast", referenced from:
```

<details>

```console
SHERPA_BUILD_DEBUG=1 cargo build --release --target aarch64-apple-ios 
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
   Compiling once_cell v1.19.0
   Compiling pin-project-lite v0.2.14
   Compiling indenter v0.3.3
   Compiling hound v3.5.1
   Compiling sherpa-rs-sys v0.5.1 (/Volumes/Internal/sherpa-rs/crates/sherpa-rs-sys)
   Compiling eyre v0.6.12
   Compiling tracing-core v0.1.32
   Compiling tracing v0.1.40
warning: sherpa-rs-sys@0.5.1: [DEBUG] target_os = ios
warning: sherpa-rs-sys@0.5.1: [DEBUG] TARGET: "aarch64-apple-ios"
warning: sherpa-rs-sys@0.5.1: [DEBUG] TARGET: aarch64-apple-ios
warning: sherpa-rs-sys@0.5.1: [DEBUG] CARGO_MANIFEST_DIR: /Volumes/Internal/sherpa-rs/crates/sherpa-rs-sys
warning: sherpa-rs-sys@0.5.1: [DEBUG] TARGET_DIR: /Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release
warning: sherpa-rs-sys@0.5.1: [DEBUG] OUT_DIR: /Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/build/sherpa-rs-sys-d0461f92d37f64a9/out
warning: sherpa-rs-sys@0.5.1: [DEBUG] Generating bindings...
warning: sherpa-rs-sys@0.5.1: [DEBUG] Writing bindings to "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/build/sherpa-rs-sys-d0461f92d37f64a9/out/bindings.rs"
warning: sherpa-rs-sys@0.5.1: [DEBUG] Bindings Created
warning: sherpa-rs-sys@0.5.1: [DEBUG] Download binaries enabled
warning: sherpa-rs-sys@0.5.1: [DEBUG] Extracting dist for target: aarch64-apple-ios
warning: sherpa-rs-sys@0.5.1: [DEBUG] raw target_dist: "{\"arch\":{\"aarch64-apple-ios\":\"ios-arm64\",\"aarch64-apple-ios-sim\":\"ios-arm64-simulator\"},\"archive\":\"sherpa-onnx-v1.10.36-ios.tar.bz2\",\"is_dynamic\":false,\"libs\":[\"build-ios/ios-onnxruntime/onnxruntime.xcframework/{arch}/libonnxruntime.a\",\"build-ios/sherpa-onnx.xcframework/{arch}/libsherpa-onnx.a\"]}"
warning: sherpa-rs-sys@0.5.1: [DEBUG] checking is_dynamic
warning: sherpa-rs-sys@0.5.1: [DEBUG] is_dynamic: false
warning: sherpa-rs-sys@0.5.1: [DEBUG] dist: Dist { url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.10.36/sherpa-onnx-v1.10.36-ios.tar.bz2", name: "sherpa-onnx-v1.10.36-ios", checksum: "da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d", libs: Some(["build-ios/ios-onnxruntime/onnxruntime.xcframework/ios-arm64/libonnxruntime.a", "build-ios/sherpa-onnx.xcframework/ios-arm64/libsherpa-onnx.a"]) }
warning: sherpa-rs-sys@0.5.1: [DEBUG] is_dynamic after: false
warning: sherpa-rs-sys@0.5.1: [DEBUG] Cache dir: /Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d
warning: sherpa-rs-sys@0.5.1: [DEBUG] Fetch file https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.10.36/sherpa-onnx-v1.10.36-ios.tar.bz2 74279040
warning: sherpa-rs-sys@0.5.1: [DEBUG] extracging tbz to /Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d
warning: sherpa-rs-sys@0.5.1: [DEBUG] dist libs: Some(["build-ios/ios-onnxruntime/onnxruntime.xcframework/ios-arm64/libonnxruntime.a", "build-ios/sherpa-onnx.xcframework/ios-arm64/libsherpa-onnx.a"])
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-search=/Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d/build-ios/ios-onnxruntime/onnxruntime.xcframework/ios-arm64
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-search=/Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d/build-ios/sherpa-onnx.xcframework/ios-arm64
warning: sherpa-rs-sys@0.5.1: [DEBUG] Skpping build with Cmake...
warning: sherpa-rs-sys@0.5.1: [DEBUG] SHERPA_LIB_PATH: /Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-search=/Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d/lib
warning: sherpa-rs-sys@0.5.1: [DEBUG] Sherpa libs: ["onnxruntime", "sherpa-onnx"]
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-search=/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/build/sherpa-rs-sys-d0461f92d37f64a9/out/lib
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-lib=static=onnxruntime
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-lib=static=sherpa-onnx
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-lib=framework=CoreML
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-lib=framework=Foundation
warning: sherpa-rs-sys@0.5.1: [DEBUG] cargo:rustc-link-lib=dylib=c++
   Compiling sherpa-rs v0.5.1 (/Volumes/Internal/sherpa-rs/crates/sherpa-rs)
error: linking with `cc` failed: exit status: 1
  |
  = note: env -u MACOSX_DEPLOYMENT_TARGET LC_ALL="C" PATH="/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin:/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin:/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin:/Users/user/go/bin:/Users/user/v:/Users/user/.gem/ruby/3.3.0/bin:/Users/user/.gem/bin:/opt/homebrew/Cellar/ruby/3.3.4/bin:/Applications/vibe.app/Contents/Resources:/Applications/CMake.app/Contents/bin:/opt/homebrew/opt/llvm/bin:/Users/user/.bun/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/usr/local/go/bin:/Users/user/Library/pnpm:/Users/user/go/bin:/Users/user/v:/Users/user/.gem/ruby/3.3.0/bin:/Users/user/.gem/bin:/opt/homebrew/Cellar/ruby/3.3.4/bin:/Applications/vibe.app/Contents/Resources:/Applications/CMake.app/Contents/bin:/opt/homebrew/opt/llvm/bin:/Users/user/.bun/bin:/Users/user/.cargo/bin:/Users/user/zig:/opt/homebrew/bin:/Users/user/flutter/bin:/Users/user/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/user/zig:/opt/homebrew/bin:/Users/user/flutter/bin" VSLANG="1033" ZERO_AR_DATE="1" "cc" "-Wl,-exported_symbols_list" "-Wl,/var/folders/k6/b4k6mjy92dxbm_l2my6zzlnm0000gn/T/rustcU4exoj/list" "-arch" "arm64" "/var/folders/k6/b4k6mjy92dxbm_l2my6zzlnm0000gn/T/rustcU4exoj/symbols.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.0.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.1.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.2.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.3.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.4.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.5.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.6.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.7.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.sherpa_rs.6bea49ca8180fac-cgu.8.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/sherpa_rs.20qdoo2or31w4g3mmm3suoh0r.rcgu.o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libsherpa_rs_sys-72aab21c5443835a.rlib" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libtracing-e2d2bb2ff4693409.rlib" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libpin_project_lite-0750fd9d5b146d91.rlib" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libtracing_core-9b5bbe4899c77c1d.rlib" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libhound-c9fb19e53c234745.rlib" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libeyre-80a8259815aa3c51.rlib" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libindenter-021e139ecfcefca9.rlib" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libonce_cell-2accaabd7fc4be4f.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libstd-899c1dc10058bab5.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libpanic_unwind-2d1d8159edc641de.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libobject-ea23f6e983a33c02.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libmemchr-62c1030a1cbf965b.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libaddr2line-b586821fd3f875ab.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libgimli-474caef0e8ea1658.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/librustc_demangle-18acde1ae19f94d8.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libstd_detect-37618758e090f176.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libhashbrown-91b5b24c41f226e8.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/librustc_std_workspace_alloc-146f4e5296100251.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libminiz_oxide-9e1add4840f216c3.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libadler-c56010c71abf1007.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libunwind-f3de18c0d04ba2cb.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libcfg_if-3738dc124f2824a0.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/liblibc-bae753c67f6f431d.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/liballoc-e8c435b244d0be60.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/librustc_std_workspace_core-301b883cf2a82c58.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libcore-70bc56e7f2f09a79.rlib" "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-ios/lib/libcompiler_builtins-019172bd7b834998.rlib" "-framework" "CoreML" "-framework" "Foundation" "-lc++" "-lSystem" "-lc" "-lm" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk" "-L" "/Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d/build-ios/ios-onnxruntime/onnxruntime.xcframework/ios-arm64" "-L" "/Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d/build-ios/sherpa-onnx.xcframework/ios-arm64" "-L" "/Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d/lib" "-L" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/build/sherpa-rs-sys-d0461f92d37f64a9/out/lib" "-o" "/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/deps/libsherpa_rs.dylib" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-nodefaultlibs"
  = note: ld: warning: search path '/Users/user/Library/Caches/sherpa-rs/aarch64-apple-ios/da82f2bb62beac3f3c01e31cd2437e0d2dbc1a69bfadcde4b12aa36e81064c8d/lib' not found
          ld: warning: search path '/Volumes/Internal/sherpa-rs/target/aarch64-apple-ios/release/build/sherpa-rs-sys-d0461f92d37f64a9/out/lib' not found
          Undefined symbols for architecture arm64:
            "___isPlatformVersionAtLeast", referenced from:
                -[CoreMLExecution predict:outputs:getOutputTensorDataFn:] in libsherpa_rs_sys-72aab21c5443835a.rlib[707](model.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `sherpa-rs` (lib) due to 1 previous error
```

</details>

Fixed with 

https://github.com/bmrlab/gendam/issues/96

```console
export RUSTFLAGS="-C link-arg=-fapple-link-rtlib"
```