### PR TITLE
Offline recognizer fixes

### DIFF
--- a/crates/sherpa-rs/src/moonshine.rs
+++ b/crates/sherpa-rs/src/moonshine.rs
@@ -1,7 +1,4 @@
-use crate::{
-    get_default_provider,
-    utils::{cstr_to_string, RawCStr},
-};
+use crate::{get_default_provider, utils::RawCStr};
 use eyre::{bail, Result};
 use std::ptr::null;
 
@@ -10,11 +7,7 @@ pub struct MoonshineRecognizer {
     recognizer: *const sherpa_rs_sys::SherpaOnnxOfflineRecognizer,
 }
 
-#[derive(Debug)]
-pub struct MoonshineRecognizerResult {
-    pub text: String,
-    // pub timestamps: Vec<f32>,
-}
+pub type MoonshineRecognizerResult = super::OfflineRecognizerResult;
 
 #[derive(Debug)]
 pub struct MoonshineConfig {
@@ -140,8 +133,7 @@ impl MoonshineRecognizer {
             sherpa_rs_sys::SherpaOnnxDecodeOfflineStream(self.recognizer, stream);
             let result_ptr = sherpa_rs_sys::SherpaOnnxGetOfflineStreamResult(stream);
             let raw_result = result_ptr.read();
-            let text = cstr_to_string(raw_result.text as _);
-            let result = MoonshineRecognizerResult { text };
+            let result = MoonshineRecognizerResult::new(&raw_result);
             // Free
             sherpa_rs_sys::SherpaOnnxDestroyOfflineRecognizerResult(result_ptr);
             sherpa_rs_sys::SherpaOnnxDestroyOfflineStream(stream);

--- a/crates/sherpa-rs/src/moonshine.rs
+++ b/crates/sherpa-rs/src/moonshine.rs
@@ -9,7 +9,7 @@ pub struct MoonshineRecognizer {
 
 pub type MoonshineRecognizerResult = super::OfflineRecognizerResult;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MoonshineConfig {
     pub preprocessor: String,
 

--- a/crates/sherpa-rs/src/moonshine.rs
+++ b/crates/sherpa-rs/src/moonshine.rs
@@ -128,7 +128,7 @@ impl MoonshineRecognizer {
         Ok(Self { recognizer })
     }
 
-    pub fn transcribe(&mut self, sample_rate: u32, samples: Vec<f32>) -> MoonshineRecognizerResult {
+    pub fn transcribe(&mut self, sample_rate: u32, samples: &[f32]) -> MoonshineRecognizerResult {
         unsafe {
             let stream = sherpa_rs_sys::SherpaOnnxCreateOfflineStream(self.recognizer);
             sherpa_rs_sys::SherpaOnnxAcceptWaveformOffline(

--- a/crates/sherpa-rs/src/utils.rs
+++ b/crates/sherpa-rs/src/utils.rs
@@ -34,7 +34,7 @@ impl Drop for RawCStr {
     }
 }
 
-pub fn cstr_to_string(ptr: *mut c_char) -> String {
+pub fn cstr_to_string(ptr: *const c_char) -> String {
     unsafe {
         if ptr.is_null() {
             String::new()

--- a/crates/sherpa-rs/src/whisper.rs
+++ b/crates/sherpa-rs/src/whisper.rs
@@ -1,7 +1,4 @@
-use crate::{
-    get_default_provider,
-    utils::{cstr_to_string, RawCStr},
-};
+use crate::{get_default_provider, utils::RawCStr};
 use eyre::{bail, Result};
 use std::ptr::null;
 
@@ -10,11 +7,7 @@ pub struct WhisperRecognizer {
     recognizer: *const sherpa_rs_sys::SherpaOnnxOfflineRecognizer,
 }
 
-#[derive(Debug)]
-pub struct WhisperRecognizerResult {
-    pub text: String,
-    // pub timestamps: Vec<f32>,
-}
+pub type WhisperRecognizerResult = super::OfflineRecognizerResult;
 
 #[derive(Debug)]
 pub struct WhisperConfig {
@@ -147,10 +140,7 @@ impl WhisperRecognizer {
             sherpa_rs_sys::SherpaOnnxDecodeOfflineStream(self.recognizer, stream);
             let result_ptr = sherpa_rs_sys::SherpaOnnxGetOfflineStreamResult(stream);
             let raw_result = result_ptr.read();
-            let text = cstr_to_string(raw_result.text as _);
-            // let timestamps: &[f32] =
-            // std::slice::from_raw_parts(raw_result.timestamps, raw_result.count as usize);
-            let result = WhisperRecognizerResult { text };
+            let result = WhisperRecognizerResult::new(&raw_result);
             // Free
             sherpa_rs_sys::SherpaOnnxDestroyOfflineRecognizerResult(result_ptr);
             sherpa_rs_sys::SherpaOnnxDestroyOfflineStream(stream);

--- a/crates/sherpa-rs/src/whisper.rs
+++ b/crates/sherpa-rs/src/whisper.rs
@@ -135,7 +135,7 @@ impl WhisperRecognizer {
         Ok(Self { recognizer })
     }
 
-    pub fn transcribe(&mut self, sample_rate: u32, samples: Vec<f32>) -> WhisperRecognizerResult {
+    pub fn transcribe(&mut self, sample_rate: u32, samples: &[f32]) -> WhisperRecognizerResult {
         unsafe {
             let stream = sherpa_rs_sys::SherpaOnnxCreateOfflineStream(self.recognizer);
             sherpa_rs_sys::SherpaOnnxAcceptWaveformOffline(
@@ -200,7 +200,7 @@ mod tests {
         let mut recognizer = WhisperRecognizer::new(config).unwrap();
 
         let start_t = Instant::now();
-        let result = recognizer.transcribe(sample_rate, samples);
+        let result = recognizer.transcribe(sample_rate, &samples);
         println!("{:?}", result);
         println!("Time taken for transcription: {:?}", start_t.elapsed());
     }

--- a/crates/sherpa-rs/src/whisper.rs
+++ b/crates/sherpa-rs/src/whisper.rs
@@ -9,7 +9,7 @@ pub struct WhisperRecognizer {
 
 pub type WhisperRecognizerResult = super::OfflineRecognizerResult;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WhisperConfig {
     pub decoder: String,
     pub encoder: String,

--- a/examples/moonshine.rs
+++ b/examples/moonshine.rs
@@ -32,7 +32,7 @@ fn main() {
     let mut recognizer = MoonshineRecognizer::new(config).unwrap();
 
     let start_t = std::time::Instant::now();
-    let result = recognizer.transcribe(sample_rate, samples);
+    let result = recognizer.transcribe(sample_rate, &samples);
     println!("✅ Text: {}", result.text);
     println!("⏱️ Time taken for transcription: {:?}", start_t.elapsed());
 }

--- a/examples/vad_whisper.rs
+++ b/examples/vad_whisper.rs
@@ -60,7 +60,7 @@ fn main() {
                 let segment = vad.front();
                 let start_sec = (segment.start as f32) / sample_rate as f32;
                 let duration_sec = (segment.samples.len() as f32) / sample_rate as f32;
-                let transcript = recognizer.transcribe(sample_rate, segment.samples.clone());
+                let transcript = recognizer.transcribe(sample_rate, &segment.samples);
 
                 // Compute the speaker embedding
                 let mut embedding = extractor
@@ -96,7 +96,7 @@ fn main() {
             let segment = vad.front();
             let start_sec = (segment.start as f32) / sample_rate as f32;
             let duration_sec = (segment.samples.len() as f32) / sample_rate as f32;
-            let transcript = recognizer.transcribe(sample_rate, segment.samples.clone());
+            let transcript = recognizer.transcribe(sample_rate, &segment.samples);
 
             // Compute the speaker embedding
             let mut embedding = extractor

--- a/examples/whisper.rs
+++ b/examples/whisper.rs
@@ -32,7 +32,7 @@ fn main() {
     let mut recognizer = WhisperRecognizer::new(config).unwrap();
 
     let start_t = std::time::Instant::now();
-    let result = recognizer.transcribe(sample_rate, samples);
+    let result = recognizer.transcribe(sample_rate, &samples);
     println!("✅ Text: {}", result.text);
     println!("⏱️ Time taken for transcription: {:?}", start_t.elapsed());
 }


### PR DESCRIPTION
* Make WhisperConfig / Moonshine config clonable; saves the owner having to do their own wrapping to make it clonable.
* Change `transcribe` in `WhisperRecognizer` and `MoonshineRecognizer` take a `&[f32]` slice since ownership isn't needed. This is a backwards-incompatible change - not sure if a problem or not. Maybe the method could be made generic to somehow accept either Vec<f32> or &[f32] (AsRef?)?
* Construct timestamps and samples for both whisper & moonshine.

One problem I've encountered is I'm not sure how to get the whisper recognizer to actually emit the timestamps to check if they're correct - is something missing in the config / stream setup? I've verified that the tokens do get generated and are converted into a Vec<String> correctly.