### PR TITLE
Set the minimum required CMake version to 3.5

### DIFF
--- a/crates/sherpa-rs-sys/build.rs
+++ b/crates/sherpa-rs-sys/build.rs
@@ -412,6 +412,8 @@ fn main() {
             .unwrap_or(true);
         let mut config = Config::new(&sherpa_dst);
 
+        config.define("CMAKE_POLICY_VERSION_MINIMUM", "3.5");
+
         config
             .define("SHERPA_ONNX_ENABLE_C_API", "ON")
             .define("SHERPA_ONNX_ENABLE_BINARY", "OFF")


### PR DESCRIPTION
This patch bumps the minimum required CMake version to 3.5 in order to restore compatibility with older CMake releases. As of CMake 4.0.0, support for versions below 3.5 was removed, causing our sherpa-rs-sys build to fail unless the policy version is explicitly specified.

### Related Issue
https://github.com/thewh1teagle/sherpa-rs/issues/96