### PR TITLE
fix(build): Fix environment variable check in main function

### DIFF
--- a/crates/sherpa-rs-sys/build.rs
+++ b/crates/sherpa-rs-sys/build.rs
@@ -228,6 +228,9 @@ fn main() {
         if !env::var("RUSTFLAGS")
             .unwrap_or_default()
             .contains("relocation-model=dynamic-no-pic")
+            && !env::var("CARGO_ENCODED_RUSTFLAGS")
+                .unwrap_or_default()
+                .contains("relocation-model=dynamic-no-pic")
         {
             panic!(
                 "cargo:warning=\


### PR DESCRIPTION
Add check for the CARGO_ENCODED_RUSTFLAGS environment variable to ensure the correctness of the relocation-model=dynamic-no-pic option.

Configure the following in .cargo/config.toml: 
```toml
[target.x86_64-unknown-linux-gnu]
rustflags = ["-C", "relocation-model=dynamic-no-pic"]
```

rustc uses the CARGO_ENCODED_RUSTFLAGS environment variable. See: [https://doc.rust-lang.org/cargo/reference/environment-variables.html](https://doc.rust-lang.org/cargo/reference/environment-variables.html)

